### PR TITLE
Build: Debug: Use /DEBUG:FASTLINK

### DIFF
--- a/Bin/ENgine/CppBuild/CMakeLists.txt
+++ b/Bin/ENgine/CppBuild/CMakeLists.txt
@@ -25,7 +25,7 @@ set_target_properties(gameplay PROPERTIES OUTPUT_NAME "gameplay_Release")
 set_target_properties(gameplay PROPERTIES DEBUG_OUTPUT_NAME "gameplay_Debug")
 set_target_properties(gameplay PROPERTIES RUNTIME_OUTPUT_DIRECTORY $<1:${CMAKE_SOURCE_DIR}/../Binaries/Win64>)
 
-target_link_options(gameplay PUBLIC /DEBUG)
+target_link_options(gameplay PUBLIC /DEBUG:FASTLINK)
 
 target_link_libraries(gameplay optimized "$EDITOR_DIR/ENgine/CppBuild/lib/eastl.lib" optimized "$EDITOR_DIR/ENgine/CppBuild/lib/Oak.lib")
 target_link_libraries(gameplay debug "$EDITOR_DIR/ENgine/CppBuild/lib/eastl_Debug.lib" debug "$EDITOR_DIR/ENgine/CppBuild/lib/Oak_Debug.lib")

--- a/Projects/Windows/Editor/Editor.vcxproj
+++ b/Projects/Windows/Editor/Editor.vcxproj
@@ -127,7 +127,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <AdditionalDependencies>..\..\..\Bin\ENgine\CppBuild\lib\Oak_Debug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)/DebugInfo/$(TargetName).pdb</ProgramDatabaseFile>
     </Link>

--- a/Projects/Windows/Oak/Oak.vcxproj
+++ b/Projects/Windows/Oak/Oak.vcxproj
@@ -127,7 +127,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <AdditionalDependencies>..\..\..\Bin\ENgine\CppBuild\lib\eastl_Debug.lib;..\..\..\Libs\physx\libs\debug\PhysXCooking_64.lib;..\..\..\Libs\physx\libs\debug\PhysXCommon_64.lib;..\..\..\Libs\physx\libs\debug\PhysX_64.lib;..\..\..\Libs\physx\libs\debug\PhysXTask_static_64.lib;..\..\..\Libs\physx\libs\debug\PhysXCharacterKinematic_static_64.lib;..\..\..\Libs\physx\libs\debug\PhysXExtensions_static_64.lib;..\..\..\Libs\physx\libs\debug\PhysXFoundation_64.lib;..\..\..\Libs\physx\libs\debug\SceneQuery_static_64.lib;..\..\..\Libs\fmod\libs\fmod_vc.lib;..\..\..\Libs\fmod\libs\fmodL_vc.lib;dxgi.lib;d3d11.lib;dxguid.lib;d3dcompiler.lib;dinput8.lib;xinput.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)/DebugInfo/$(TargetName).pdb</ProgramDatabaseFile>
       <ImportLibrary>$(OutDir)/ENgine/CppBuild/lib/$(TargetName).lib</ImportLibrary>


### PR DESCRIPTION
By some reason it fixes debugging from vscode.
